### PR TITLE
[ADD] post 목록 GET & Cursor Paging 적용

### DIFF
--- a/src/main/java/com/ii/controller/PostController.java
+++ b/src/main/java/com/ii/controller/PostController.java
@@ -3,15 +3,19 @@ package com.ii.controller;
 import java.util.List;
 import java.util.UUID;
 
+import org.hibernate.validator.constraints.Range;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ii.object.entity.Post;
 import com.ii.object.model.DTO.GetPostResDTO;
+import com.ii.object.model.DTO.GetPostsResDTO;
 import com.ii.object.model.common.Response;
 import com.ii.repository.IPostRepository;
 import com.ii.service.PostService;
@@ -23,6 +27,7 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 @Log4j2
 @RestController
+@Validated
 @RequestMapping("/posts")
 public class PostController {
 	
@@ -42,10 +47,17 @@ public class PostController {
 		
 	}
 	
-	@GetMapping("/test")
-	public ResponseEntity<Response> test() {
-		
-		List<Post> posts = postRepository.findAll();
-		return ResponseUtil.build(HttpStatus.OK, "", posts);
+	@GetMapping("")
+	public ResponseEntity<Response> getPosts(
+			@Range(min = 1, max = 20) @RequestParam(name = "count", defaultValue = "5") Integer count,
+			@RequestParam(name = "cursor", required = false) UUID cursor,
+			@RequestParam(name = "post_types", defaultValue = "X,Soop,Instagram,Cafe") String postTypes
+	) {
+		try {
+			GetPostsResDTO getPostsResDTO = postService.getPosts(count, cursor, postTypes);
+			return ResponseUtil.build(HttpStatus.OK, "", getPostsResDTO);
+		} catch (IllegalArgumentException e) {
+			return ResponseUtil.build(HttpStatus.BAD_REQUEST, e.getMessage(), null);
+		}
 	}
 }

--- a/src/main/java/com/ii/object/entity/Base.java
+++ b/src/main/java/com/ii/object/entity/Base.java
@@ -1,27 +1,44 @@
 package com.ii.object.entity;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.MappedSuperclass;
-import lombok.Data;
+import com.ii.object.model.enums.BroadcastStatus;
 
-@MappedSuperclass
-@Data
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
 public abstract class Base {
 	
 	/*
 	 * BaseEntity
 	 * created_at과 updated_at 필드를 남김
 	 */
+	
+	@Id
+	@Builder.Default
+	private UUID id = UUID.randomUUID();
 
-    @Column(updatable = false)
+    @Column(updatable = false, columnDefinition= "TIMESTAMP WITH TIME ZONE")
     @CreationTimestamp
     private LocalDateTime createdAt;	// 생성 시각
     
+    @Column(columnDefinition= "TIMESTAMP WITH TIME ZONE")
     @UpdateTimestamp
     private LocalDateTime updatedAt;	// 마지막 업데이트 시각
 }

--- a/src/main/java/com/ii/object/entity/CafePost.java
+++ b/src/main/java/com/ii/object/entity/CafePost.java
@@ -42,7 +42,7 @@ public class CafePost extends Base {
 	@Column(columnDefinition = "TEXT")
 	private String content;
 	
-	@Column(name = "uploaded_at")
+	@Column(name = "uploaded_at", columnDefinition= "TIMESTAMP WITH TIME ZONE")
 	private LocalDateTime uploadedAt;
 	
 	@ManyToOne

--- a/src/main/java/com/ii/object/entity/ChatRecord.java
+++ b/src/main/java/com/ii/object/entity/ChatRecord.java
@@ -42,7 +42,7 @@ public class ChatRecord extends Base {
 	@Column(name = "chat_type")
 	private ChatType chatType;
 	
-	@Column(name = "sent_at")
+	@Column(name = "sent_at", columnDefinition= "TIMESTAMP WITH TIME ZONE")
 	private LocalDateTime sentAt;
 	
 	@ManyToOne

--- a/src/main/java/com/ii/object/entity/IgPost.java
+++ b/src/main/java/com/ii/object/entity/IgPost.java
@@ -43,7 +43,7 @@ public class IgPost extends Base {
 	@Column(columnDefinition = "TEXT")
 	private String content;
 	
-	@Column(name = "uploaded_at")
+	@Column(name = "uploaded_at", columnDefinition= "TIMESTAMP WITH TIME ZONE")
 	private LocalDateTime uploadedAt;
 	
 	@ManyToOne

--- a/src/main/java/com/ii/object/entity/Post.java
+++ b/src/main/java/com/ii/object/entity/Post.java
@@ -45,6 +45,9 @@ public class Post {
 	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Streamer streamer;
 	
+	@Column(name = "uploaded_at", columnDefinition= "TIMESTAMP WITH TIME ZONE")
+	private LocalDateTime uploadedAt;
+	
 	@OneToOne
 	@JoinColumn(name = "cafe_post_id")
 	@OnDelete(action = OnDeleteAction.CASCADE)

--- a/src/main/java/com/ii/object/entity/SoopPost.java
+++ b/src/main/java/com/ii/object/entity/SoopPost.java
@@ -46,7 +46,7 @@ public class SoopPost extends Base {
 	@Column(columnDefinition = "TEXT")
 	private String content;
 	
-	@Column(name = "uploaded_at")
+	@Column(name = "uploaded_at", columnDefinition= "TIMESTAMP WITH TIME ZONE")
 	private LocalDateTime uploadedAt;
 	
 	@ManyToOne

--- a/src/main/java/com/ii/object/entity/XPost.java
+++ b/src/main/java/com/ii/object/entity/XPost.java
@@ -50,7 +50,7 @@ public class XPost extends Base {
 	@Column(columnDefinition = "TEXT")
 	private String content;
 	
-	@Column(name = "uploaded_at")
+	@Column(name = "uploaded_at", columnDefinition= "TIMESTAMP WITH TIME ZONE")
 	private LocalDateTime uploadedAt;
 	
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/ii/object/entity/YtPost.java
+++ b/src/main/java/com/ii/object/entity/YtPost.java
@@ -46,7 +46,7 @@ public class YtPost extends Base {
 	@Column(columnDefinition = "TEXT")
 	private String content;
 	
-	@Column(name = "uploaded_at")
+	@Column(name = "uploaded_at", columnDefinition= "TIMESTAMP WITH TIME ZONE")
 	private LocalDateTime uploadedAt;
 	
 	@ManyToOne

--- a/src/main/java/com/ii/object/model/DTO/GetPostsResDTO.java
+++ b/src/main/java/com/ii/object/model/DTO/GetPostsResDTO.java
@@ -1,0 +1,21 @@
+package com.ii.object.model.DTO;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.ii.object.model.enums.PostType;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@AllArgsConstructor
+@Data
+public class GetPostsResDTO {
+
+	private final int count;
+	private UUID after;
+	private List<PostType> postTypes;
+	private List<GetPostResDTO> posts;
+	
+}

--- a/src/main/java/com/ii/repository/IPostRepository.java
+++ b/src/main/java/com/ii/repository/IPostRepository.java
@@ -1,11 +1,25 @@
 package com.ii.repository;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ii.object.entity.Post;
+import com.ii.object.model.enums.PostType;
 
 public interface IPostRepository extends JpaRepository<Post, UUID> {
 
+	List<Post> findAllByOrderByUploadedAtDesc(Pageable pageable);
+
+	List<Post> findByUploadedAtLessThanOrderByUploadedAtDesc(LocalDateTime uploadedAt, Pageable pageable);
+
+	List<Post> findByTypeInOrderByUploadedAtDesc(ArrayList<PostType> postTypeList, Pageable pageable);
+
+	List<Post> findByUploadedAtLessThanAndTypeInOrderByUploadedAtDesc(LocalDateTime uploadedAt,
+			ArrayList<PostType> postTypeList, Pageable pageable);
+	
 }

--- a/src/main/java/com/ii/service/PostService.java
+++ b/src/main/java/com/ii/service/PostService.java
@@ -1,12 +1,19 @@
 package com.ii.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
+import com.ii.object.entity.Base;
 import com.ii.object.entity.Post;
 import com.ii.object.model.DTO.GetPostResDTO;
+import com.ii.object.model.DTO.GetPostsResDTO;
 import com.ii.object.model.enums.PostType;
 import com.ii.repository.IPostRepository;
 import com.ii.utils.AsyncMailSender;
@@ -32,6 +39,37 @@ public class PostService {
 		};
 		
 		return new GetPostResDTO(post.getId(), post.getType(), post.getStreamer(), data);
+		
+	}
+	
+	public GetPostsResDTO getPosts(int count, UUID cursor, String postTypes) throws IllegalArgumentException {
+		
+		ArrayList<PostType> postTypeList = new ArrayList<PostType>();
+		for(String postTypeString : postTypes.split(",")) {
+			PostType postType = PostType.valueOf(postTypeString);
+			postTypeList.add(postType);
+		}
+		
+		Pageable pageable = PageRequest.of(0, count);
+		List<Post> posts;
+		if(cursor == null) {
+			posts = postRepository.findByTypeInOrderByUploadedAtDesc(postTypeList, pageable);
+		} else {
+			Post cursorPost = postRepository.findById(cursor)
+					.orElseThrow(() -> new IllegalArgumentException("No post with id " + cursor.toString()));
+			posts = postRepository.findByUploadedAtLessThanAndTypeInOrderByUploadedAtDesc(cursorPost.getUploadedAt(), postTypeList, pageable);
+		}
+		
+		return new GetPostsResDTO(posts.size(), cursor, postTypeList, posts.stream().map(post -> {
+			Object data = switch (post.getType()) {
+				case PostType.Cafe		-> post.getCafePost();
+				case PostType.Soop		-> post.getSoopPost();
+				case PostType.X 		-> post.getXPost();
+				case PostType.Instagram	-> post.getIgPost();
+				default 				-> throw new IllegalArgumentException("Unexpected value: " + post.getType());
+			};
+			return new GetPostResDTO(post.getId(), post.getType(), post.getStreamer(), data);
+		}).collect(Collectors.toList()));
 		
 	}
 	


### PR DESCRIPTION
[ADD] post list GET with cursor paging and type filter

GET /api/posts
Query String:
count => 1~20
cursor => post의 Id 값, 해당 id를 가진 post 다음 글부터 불러옴
post_types => X, Soop, Instagram, Cafe 4가지가 있고 ","를 붙여서 여러 타입 동시 검색 가능 ex) X,Soop => X랑 Soop Post만 불러옴

ex) /api/posts?count=20&cursor=e36f2a4f-593c-4f1a-a956-c30cda412e4e&post_types=Soop,X